### PR TITLE
use property descriptor for detecting setters

### DIFF
--- a/src/lib/registerStore.svelte.ts
+++ b/src/lib/registerStore.svelte.ts
@@ -53,10 +53,10 @@ export const registerStore = (
       const keys = Object.keys(storedObject)
       keys.forEach(key => {
         if (store[key] !== storedObject[key]) {
-          try {
+          const properties = Object.getOwnPropertyDescriptor(store, key)
+          // if property has setter
+          if (properties?.set) {
             store[key] = storedObject[key]
-          } catch (_error) {
-            // key is read-only
           }
         }
       })


### PR DESCRIPTION
use property descriptors for seeing if a key has a setter rather than a try catch block