### PR TITLE
read and assign store value before svelte mount

### DIFF
--- a/src/lib/registerStore.svelte.ts
+++ b/src/lib/registerStore.svelte.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { onMount, untrack } from 'svelte'
+import { untrack } from 'svelte'
 
 export type SvStoreType = 'localStorage' | 'sessionStorage'
 
@@ -22,8 +22,6 @@ export const registerStore = (
 ) => {
   if (typeof window === 'undefined') return
 
-  let mounted: boolean = false
-
   const prefix =
     options?.prefix === null ? null : (options?.prefix ?? 'sv-store')
   const key = prefix ? `${prefix}:${name}` : name
@@ -34,7 +32,7 @@ export const registerStore = (
     untrack(() => options?.beforeWrite?.(store))
 
     const copy = { ...state }
-    if (mounted) space.setItem(key, JSON.stringify(copy))
+    space.setItem(key, JSON.stringify(copy))
 
     untrack(() => options?.afterWrite?.(store))
   }
@@ -60,10 +58,6 @@ export const registerStore = (
   }
 
   readStore()
-
-  onMount(() => {
-    mounted = true
-  })
 
   $effect(() => storeEffect(store))
 }


### PR DESCRIPTION
`readStore` before svelte mount is called to fix value used in `onMount` hook being initial value defined for the store when value in local storage or session storage is set and has a different value