### PR TITLE
tab sync opt in

### DIFF
--- a/src/docs/examples/callback/Callback.svelte
+++ b/src/docs/examples/callback/Callback.svelte
@@ -18,6 +18,7 @@ const log = (event: string, state: CallbackState) => {
 }
 
 registerStore('callback', useCallbackStore(), {
+  tabSynchronization: true,
   beforeRead: value => log('beforeRead', value),
   afterRead: value => log('afterRead', value),
   beforeWrite: value => log('beforeWrite', value),

--- a/src/docs/examples/counter/Counter.svelte
+++ b/src/docs/examples/counter/Counter.svelte
@@ -2,7 +2,9 @@
 import { registerStore } from '$lib/registerStore.svelte'
 import { useCounterStore } from './counter.svelte.ts'
 
-registerStore('counter', useCounterStore())
+registerStore('counter', useCounterStore(), {
+  tabSynchronization: true,
+})
 let counterStore = useCounterStore()
 </script>
 

--- a/src/lib/registerStore.svelte.ts
+++ b/src/lib/registerStore.svelte.ts
@@ -19,7 +19,7 @@ export type SvStoreOptions = {
 const DEFAULT_OPTIONS: SvStoreOptions = {
   type: 'localStorage',
   prefix: 'sv-store',
-  tabSynchronization: true,
+  tabSynchronization: false,
   writeUnchanged: false,
   serialize: value => JSON.stringify(value),
   deserialize: value => JSON.parse(value),

--- a/src/routes/api/+page.svx
+++ b/src/routes/api/+page.svx
@@ -41,7 +41,7 @@ Namespaces the storage key as `{prefix}:{name}`. Set to `null` to use the name a
 
 | type    | default |
 | :------ | :------ |
-| boolean | true    |
+| boolean | false   |
 
 Whether to sync state across tabs.
 

--- a/src/routes/callback/+page.svx
+++ b/src/routes/callback/+page.svx
@@ -52,6 +52,7 @@ Pass callbacks on registration:
 
 ```ts
 registerStore('callback', useCallbackStore(), {
+  tabSynchronization: true,
   beforeRead: store => console.log('beforeRead', store),
   afterRead: store => console.log('afterRead', store),
   beforeWrite: store => console.log('beforeWrite', store),

--- a/src/routes/counter/+page.svx
+++ b/src/routes/counter/+page.svx
@@ -67,7 +67,9 @@ Register the store once in your main file or root layout file
 import { registerStore } from 'sv-store'
 import { useCounterStore } from './counter.svelte.ts'
 
-registerStore('counter', useCounterStore())
+registerStore('counter', useCounterStore(), {
+  tabSynchronization: true,
+})
 // stored in localStorage under `sv-store:counter`
 ```
 


### PR DESCRIPTION
Changed the default value of `tabSynchronization` from `true` to `false`, this behaviour should be opt in rather than opt out after our findings with #9